### PR TITLE
Enable Vercel deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+build/
+# others

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Aplikacja została przekonfigurowana do działania z Vercel Functions zamiast Ex
 ### Struktura dla Vercel:
 
 - `api/messages.ts` - Vercel Function obsługująca wiadomości
-- `vercel.json` - Konfiguracja Vercel
+- `vercel.json` - Konfiguracja Vercel (z ustawioną opcją "version": 2)
 - `dist/public/` - Statyczne pliki frontenda (po build)
 
 ### Różnice od Express:

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,11 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import {
+  createServer as createViteServer,
+  createLogger,
+  type ServerOptions,
+} from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,10 +24,10 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
-    allowedHosts: true,
+    allowedHosts: true as true,
   };
 
   const vite = await createViteServer({

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "version": 2,
   "rewrites": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
## Summary
- add Vercel version config
- document config in README
- type Vite server options to fix `npm run check`
- ignore `node_modules`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_686369b86cc883278b75f0fa50294944